### PR TITLE
Alex.richey/change logger conf

### DIFF
--- a/orca-web/config/orca.yml
+++ b/orca-web/config/orca.yml
@@ -46,7 +46,7 @@ tasks:
   useWaitForAllNetflixAWSInstancesDownTask: false
 
 logging:
-  config: classpath:logback-defaults.xml
+  config: classpath:logback-dd.xml
 
 # This configuration lets you configure Webhook stages that will appear as native stages in the Deck UI.
 # Properties that are set here will not be displayed in the GUI

--- a/orca-web/src/main/resources/logback-dd.xml
+++ b/orca-web/src/main/resources/logback-dd.xml
@@ -1,6 +1,4 @@
 <configuration>
-  <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-
   <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
   </appender>

--- a/orca-web/src/main/resources/logback-dd.xml
+++ b/orca-web/src/main/resources/logback-dd.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright 2015 Netflix, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License")
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+  <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+
+  <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="JSON" />
+  </root>
+</configuration>

--- a/orca-web/src/main/resources/logback-dd.xml
+++ b/orca-web/src/main/resources/logback-dd.xml
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright 2015 Netflix, Inc.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License")
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~    http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <configuration>
   <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
 


### PR DESCRIPTION
Changes the default logger to use JSON with the logstash encoder. The logstash encoder is already a dependency of the orca project. (hoooray!)

Leaving the default logback config in the project, rather than overwrite, so it's obvious that we're overriding. 